### PR TITLE
Document Screenshot button (0x24)

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -128,6 +128,7 @@ above 100%.
 |-----------|--------------|------------------------------------------------------------|
 | `0x20`    | Emote        | Send social emote (use analog value to specify emote type) |
 | `0x21`    | Push to Talk | Activate microphone for voice input                        |
+| `0x24`    | Screenshot   | Take an in-game screenshot                                 |
 
 **Emote Analog Values:**
 - `0x00` = No emote / Released

--- a/examples/python/protocol_parser.py
+++ b/examples/python/protocol_parser.py
@@ -30,6 +30,7 @@ BUTTON_NAMES = {
     # Social/Emotes (0x20-0x2F)
     0x20: "Emote",
     0x21: "Push to Talk",
+    0x24: "Screenshot",
     # Training Controls (0x30-0x3F)
     0x30: "Increase Difficulty",
     0x31: "Decrease Difficulty",

--- a/examples/python/test_examples.py
+++ b/examples/python/test_examples.py
@@ -129,6 +129,7 @@ def test_button_names():
     assert 0x10 in BUTTON_NAMES, "Up (0x10) missing"
     assert 0x14 in BUTTON_NAMES, "Select/Confirm (0x14) missing"
     assert 0x20 in BUTTON_NAMES, "Emote (0x20) missing"
+    assert 0x24 in BUTTON_NAMES, "Screenshot (0x24) missing"
     assert 0x30 in BUTTON_NAMES, "Increase Difficulty (0x30) missing"
     
     print("  ✓ All button name mapping tests passed")


### PR DESCRIPTION
Adds `0x24` Screenshot to the Social/Emotes block (0x20-0x2F) with standard digital press/release semantics. The ID is already implemented in the wild but was missing from the spec — documenting it so implementers can support it consistently.

Also adds the ID to the example `protocol_parser.py` button name table; example tests pass.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)